### PR TITLE
Fix Redis cache expiry units and await on getValue

### DIFF
--- a/src/click-house/services/click-house.service.ts
+++ b/src/click-house/services/click-house.service.ts
@@ -40,7 +40,7 @@ export class ClickHouseService implements OnModuleInit, OnModuleDestroy {
             application: "app-logs-consumer",
         });
         this.cacheExpiryTime =
-            this.configService.get<number>("REDIS_TTL") ?? 2 * 60 * 1000; // 2 minutes
+            this.configService.get<number>("REDIS_TTL") ?? 2 * 60; // 2 minutes in seconds
         this.environment =
             this.configService.get<string>("NODE_ENV") ?? NodeEnv.LOCAL;
     }

--- a/src/redis/services/redis.service.ts
+++ b/src/redis/services/redis.service.ts
@@ -22,7 +22,7 @@ export class RedisService {
 
     async getValue(key: string): Promise<string | null> {
         try {
-            return this.redisClient.get(key);
+            return await this.redisClient.get(key);
         } catch (error) {
             this.logger.warn(`Error getting value from Redis: ${error}`);
             return null;


### PR DESCRIPTION
## Summary
- ensure Redis TTL uses seconds in ClickHouse service
- fix RedisService.getValue so that errors are caught properly

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package 'eslint')*

------
https://chatgpt.com/codex/tasks/task_e_6860db97f4548322b2fdf71df8a8458a