### PR TITLE
docs: fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 - **NestJS** – Backend framework  
 - **ClickHouse DB** – Analytics storage  
-- **Kafka** – stream proccessing
+- **Kafka** – stream processing
 
 ---
 


### PR DESCRIPTION
## Summary
- fix typo in README

## Testing
- `grep -n "stream processing" -n README.md`


------
https://chatgpt.com/codex/tasks/task_e_6860de04fe188322a5841db663a60ea9