### PR TITLE
fix: correct ClickHouse table definition

### DIFF
--- a/click-house.sql
+++ b/click-house.sql
@@ -4,7 +4,7 @@ CREATE TABLE IF NOT EXISTS app_logs (
     `msg` Nullable(String),
     `hostname` Nullable(String),
     `env` Nullable(String),
-    `app_name` Nullable(String),
+    `app_name` Nullable(String)
 )
 ENGINE = MergeTree()
 PARTITION BY toYYYYMM(log_timestamp)


### PR DESCRIPTION
## Summary
- fix trailing comma in `app_logs` ClickHouse table definition

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860de78f4788322ba6df1af4473dca8